### PR TITLE
sepolicy: isolate power HAL policies into a new subdirectory

### DIFF
--- a/common/vendor/vendor_init.te
+++ b/common/vendor/vendor_init.te
@@ -1,2 +1,5 @@
 # FM Radio app properties
 set_prop(vendor_init, vendor_fm_radio_app_prop);
+
+# To write to VM nodes
+allow vendor_init proc_dirty:file w_file_perms;

--- a/libperfmgr/sepolicy.mk
+++ b/libperfmgr/sepolicy.mk
@@ -1,0 +1,2 @@
+BOARD_VENDOR_SEPOLICY_DIRS += \
+    device/lineage/sepolicy/libperfmgr/vendor

--- a/libperfmgr/vendor/hal_power_default.te
+++ b/libperfmgr/vendor/hal_power_default.te
@@ -1,0 +1,7 @@
+# To do powerhint on nodes defined in powerhint.json
+allow hal_power_default cgroup:dir search;
+allow hal_power_default cgroup:file rw_file_perms;
+allow hal_power_default sysfs_devices_system_cpu:file rw_file_perms;
+
+# To get/set powerhal state property
+set_prop(hal_power_default, vendor_power_prop)

--- a/libperfmgr/vendor/property.te
+++ b/libperfmgr/vendor/property.te
@@ -1,0 +1,2 @@
+# Power HAL
+vendor_public_prop(vendor_power_prop);

--- a/libperfmgr/vendor/property_contexts
+++ b/libperfmgr/vendor/property_contexts
@@ -1,0 +1,2 @@
+# Power HAL
+vendor.powerhal.                   u:object_r:vendor_power_prop:s0

--- a/libperfmgr/vendor/vendor_init.te
+++ b/libperfmgr/vendor/vendor_init.te
@@ -1,0 +1,2 @@
+# To set powerhal init property
+set_prop(vendor_init, vendor_power_prop)


### PR DESCRIPTION
This makes power HAL policies opt-in. Primary reason to do this is to avoid breaking Pixel builds, which have several conflicting policies.

Change-Id: I66197a7145d424984acf31fe07d282d6e5bcdc8b